### PR TITLE
adding filter and subsetting options

### DIFF
--- a/sensorgridapi/sensordata/views.py
+++ b/sensorgridapi/sensordata/views.py
@@ -12,8 +12,6 @@ def sensordata_list(request, format=None):
     List all code snippets, or create a new snippet.
     """
     if request.method == 'GET':
-        print(request.GET)
-        print("HI!!")
         sensordata = SensorData.objects.all()
 
         # for filtering data by certain field conditions


### PR DESCRIPTION
Adding filter options by node_id, created_at. All other fields aren't set to be filtered for now.

Instead, you can view all other fields separately by calling `http://127.0.0.1:8000/sensordata/?field_type`